### PR TITLE
Adjusted the row and column grid

### DIFF
--- a/easy/calculator/index.html
+++ b/easy/calculator/index.html
@@ -14,6 +14,7 @@
         <div data-previous-operand class="previous-operand"></div>
         <div data-current-operand class="current-operand"></div>
       </div>
+      
       <button data-all-clear class="span-two">AC</button>
       <button data-delete>DEL</button>
       <button data-operation>÷</button>

--- a/easy/calculator/style.css
+++ b/easy/calculator/style.css
@@ -17,8 +17,8 @@ body {
   justify-content: center;
   align-content: center;
   min-height: 100vh;
-  grid-template-columns: repeat(4, 100px);
-  grid-template-rows: minmax(120px, auto) repeat(5, 100px);
+  grid-template-columns: repeat(4, 80px);
+  grid-template-rows: minmax(80px, auto) repeat(5, 60px);
 }
 
 .calculator-grid > button {


### PR DESCRIPTION
## Previously full calculator was not fit to the screen creating trouble to find the '=' (equals to button) 
![image](https://user-images.githubusercontent.com/84634405/193764309-e2b0edc4-d470-4de2-86ee-81721fc47965.png)

## By adjusting the Column Aspect ratio the whole calculator can be fitted to the screen which leads to ease of doing calculations with the calculator.
![image](https://user-images.githubusercontent.com/84634405/193764590-16de940c-d2a6-43d1-bb67-b85096c781d9.png)
